### PR TITLE
Update Gemfile.lock to https

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
     listen (0.5.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     coolline (0.3.0)
     guard-motion (0.1.0)


### PR DESCRIPTION
As the title says, if you're going to include the .lock file, it should probably be on https :)
Note it's often considered good practise for Gem developers not to commit the .lock file, as it can produce false positives
