### PR TITLE
Count the number of calls to a stub

### DIFF
--- a/lib/webstub/stub.rb
+++ b/lib/webstub/stub.rb
@@ -5,10 +5,12 @@ module WebStub
     def initialize(method, url)
       @request_method = canonicalize_method(method)
       raise ArgumentError, "invalid method name" unless METHODS.include? @request_method
-      
+
       @request_url = canonicalize_url(url)
       @request_headers = nil
       @request_body = nil
+
+      @call_count = 0
 
       @response_body = ""
       @response_delay = 0.0
@@ -40,9 +42,11 @@ module WebStub
         end
       end
 
+      @call_count += 1
       true
     end
 
+    attr_reader :call_count
     attr_reader :response_body
     attr_reader :response_delay
     attr_reader :response_headers

--- a/spec/stub_spec.rb
+++ b/spec/stub_spec.rb
@@ -17,6 +17,19 @@ describe WebStub::Stub do
     lambda { WebStub::Stub.new("invalid", "http://www.yahoo.com/") }.should.raise(ArgumentError)
   end
 
+  describe '#call_count' do
+    it 'increments call count when provided with a matching stub' do
+      @stub.matches? :get, "http://www.yahoo.com/"
+      @stub.call_count.should.equal 1
+    end
+
+    it 'doesnt increment call count when matched against other urls, methods' do
+      @stub.matches? :get, "http://www.google.com/"
+      @stub.matches? :post, "http://www.yahoo.com/"
+      @stub.call_count.should.equal 0
+    end
+  end
+
   describe "#matches?" do
     it "returns true when provided an identical stub" do
       @stub.matches?(:get, "http://www.yahoo.com/").should.be.true


### PR DESCRIPTION
In order to facilitate expectations on stubs having been accessed, count the calls to a stub
