### PR TITLE
`defaultSessionConfiguration.protocolClasses` no longer empty

### DIFF
--- a/lib/webstub/patch/session_configuration.rb
+++ b/lib/webstub/patch/session_configuration.rb
@@ -8,7 +8,7 @@ if Kernel.const_defined?(:NSURLSessionConfiguration)
 
         protocols = config.protocolClasses.clone || []
         unless protocols.include?(WebStub::Protocol)
-          protocols << WebStub::Protocol
+          protocols.unshift WebStub::Protocol
           config.protocolClasses = protocols
         end
 
@@ -22,7 +22,7 @@ if Kernel.const_defined?(:NSURLSessionConfiguration)
 
         protocols = config.protocolClasses.clone || []
         unless protocols.include?(WebStub::Protocol)
-          protocols << WebStub::Protocol
+          protocols.unshift WebStub::Protocol
           config.protocolClasses = protocols
         end
 


### PR DESCRIPTION
In iOS 8:

```
ap  NSURLSessionConfiguration.defaultSessionConfiguration.protocolClasses
[
    [0] _NSURLHTTPProtocol < _NSCFURLProtocol,
    [1] _NSURLDataProtocol < _NSCFURLProtocol,
    [2] _NSURLFTPProtocol < _NSCFURLProtocol,
    [3] _NSURLFileProtocol < _NSCFURLProtocol,
    [4] NSAboutURLProtocol < NSURLProtocol
]
```

In iOS < 8:

```
ap  NSURLSessionConfiguration.defaultSessionConfiguration.protocolClasses
[]
```
