### PR TITLE
fix crash with iOS 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode7.3
 before_install:
     - (ruby --version)
     - sudo chown -R travis ~/Library/RubyMotion

--- a/lib/webstub/protocol.rb
+++ b/lib/webstub/protocol.rb
@@ -58,6 +58,10 @@ module WebStub
 
       if @stub.redirects?
         url = NSURL.URLWithString(@stub.response_headers["Location"])
+        if request.URL == url
+          # Can't redirect to same URL. Since iOS 10, it will cause a crash.
+          return
+        end
         redirect_request = NSURLRequest.requestWithURL(url)
 
         client.URLProtocol(self, wasRedirectedToRequest: redirect_request, redirectResponse: response)


### PR DESCRIPTION
This patch should fix https://hipbyte.myjetbrains.com/youtrack/issue/RM-1097

If it would access to same URL with redirection, looks like Cocoa API break the stack or buffer, heap in internal of object which will be used to request since iOS 10.
Then when objective-c runtime API would be called with broken object, it will cause a crash.

This patch will get rid of redirection to same URL.
